### PR TITLE
Remove unnecessary requires in spec db helper

### DIFF
--- a/spec/support/db/helpers.rb
+++ b/spec/support/db/helpers.rb
@@ -34,10 +34,8 @@ module Test
           begin
             case type
             when :main
-              require "main/entities"
               Main::Entities
             else
-              require "app_prototype/entities"
               AppPrototype::Entities
             end
           end


### PR DESCRIPTION
The requires in `spec/support/db/helpers.rb` don't resolve correctly. I was able to get a test working only after removing them.

I believe this is similar to https://github.com/hanami/hanami-2-application-template/pull/18

[Here's](https://github.com/afrojun/hanami-2-test-app) the app where I tested this, and this is the [specific commit](https://github.com/afrojun/hanami-2-test-app/commit/d7c243582e9e3280ac014eb2ae2d91042c758116#diff-9d20d0ad50aa2d06bfff442672c152fa900c9f59c7cf386ee59c266b9c92d7df).

Hope this helps! Please let me know if you require any further information or tests.