### PR TITLE
./bin/install fails to run for multiple reasons

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -48,6 +48,8 @@ class Installer
     def self_destruct
       shell "rm -f .github/FUNDING.yml"
       shell "rm bin/install"
+      shell "rm -f stderr.txt"
+      shell "rm -f stdout.txt"
     end
 
     def camelize(string)
@@ -61,10 +63,14 @@ class Installer
     end
 
     def shell(command, env={})
-      result = system(env, command)
+      stderr = "stderr.txt"
+      stdout = "stdout.txt"
+      result = system(env, command, {out: stdout, err: stderr })
 
       unless result
-        raise "#{command} failed with status #{$?.exitstatus}\n\n#{output}"
+        output = IO.read(stdout)
+        errput = IO.read(stderr)
+        raise "#{command} failed with status #{$?.exitstatus}\n\nSTDOUT:\n#{output}\n\nSTDERR:\n#{errput}"
       end
     end
 

--- a/bin/install
+++ b/bin/install
@@ -39,6 +39,7 @@ class Installer
     end
 
     def bundle_install
+      puts "Running bundle install - this may take a few minutes"
       shell "bundle install"
     end
 

--- a/bin/install
+++ b/bin/install
@@ -53,8 +53,6 @@ class Installer
     def self_destruct
       shell "rm -f .github/FUNDING.yml"
       shell "rm bin/install"
-      shell "rm -f stderr.txt"
-      shell "rm -f stdout.txt"
     end
 
     def camelize(string)
@@ -72,7 +70,10 @@ class Installer
       stdout = "stdout.txt"
       result = system(env, command, {out: stdout, err: stderr })
 
-      unless result
+      if result
+        File.unlink(stderr) if File.exist?(stderr)
+        File.unlink(stdout) if File.exist?(stdout)
+      else
         output = IO.read(stdout)
         errput = IO.read(stderr)
         raise "#{command} failed with status #{$?.exitstatus}\n\nSTDOUT:\n#{output}\n\nSTDERR:\n#{errput}"

--- a/bin/install
+++ b/bin/install
@@ -6,6 +6,7 @@ class Installer
     def call(app_name)
       rename_app app_name
       install_readme
+      bundle_install
       generate_cli_binstub
       self_destruct
 
@@ -35,6 +36,10 @@ class Installer
         shell "find . -depth -type #{find_type} -name '*app_prototype*' " \
               "-exec bash -c 'mv $0 ${0/app_prototype/#{snake_name}}' {} \\;"
       end
+    end
+
+    def bundle_install
+      shell "bundle install"
     end
 
     def generate_cli_binstub


### PR DESCRIPTION
## Initial Bug

Hi, I wanted to test out the new hanami 2.0.0 stack and followed the instructions give in the [README.md](https://github.com/hanami/hanami-2-application-template/blob/master/README.md)

  1. Click **Use this template** in the hanami-2-application-template repo
  2. cloned my newly created repo locally
  3. ran `./bin/install my_test_app`
 
## Expected result

A base hanami 2.0.0 alpha application to replace the existing files along with the output `Your app is ready to go!`

## Actual output

```
./bin/install:67:in `shell': undefined local variable or method `output' for Installer:Class (NameError)
```

## Investigation

Reviewing the code shows that [the `output` variable on line 67 does not exist](https://github.com/hanami/hanami-2-application-template/blob/067b4aea8b13be1b5be08c89abca751d958ef132/bin/install#L67)

Fixing this issue locally allowed me to see the real error (for me), which was that `bundle binstubs hanami-cli` failed to run successfully and exited with the error: 
```
./bin/install:71:in `shell': bundle binstubs hanami-cli failed with status 7 (RuntimeError)
Could not find hanami-cli-2.0.0.alpha2 in any of the sources
```
I believe `bundle binstubs` only works after the gem has been installed, and since I had never run `bundle install` yet - there was no `hanami-cli`gem found to install the binstubs.

## Proposed Solution

- [x] Capturing the stderr and stdout of the `system()` command in the `shell` function to allow proper reporting of errors
- [x] Running `bundle install` before `bundle binstubs`

After applying these fixes to my application template running `./bin/install my_test_app` ran successfully

Thanks for your time!
