### PR TITLE
Minimize application action code

### DIFF
--- a/lib/app_prototype/action.rb
+++ b/lib/app_prototype/action.rb
@@ -3,19 +3,8 @@
 
 require "json" # required for Hanami::Action::Flash to work
 require "hanami/action"
-require "hanami/action/cookies"
-require "hanami/action/csrf_protection"
-require "hanami/action/session"
 
 module AppPrototype
   class Action < Hanami::Action
-    def self.inherited(klass)
-      super
-
-      # These will need to be sorted by the framework eventually
-      klass.include Hanami::Action::Cookies
-      klass.include Hanami::Action::Session
-      klass.include Hanami::Action::CSRFProtection
-    end
   end
 end


### PR DESCRIPTION
## Enhancements

### Minimize application action code (`lib/app_prototype/action.rb`)

See https://github.com/hanami/controller/pull/348
Now the Action features are dynamically loaded.

### Remove `lib/hanami/action/csrf_protection.rb`.

With `dry-inflector` `v0.2.1`, it supports by default the "CSRF" acronym, so `dry-system` and `zeitwerk` can properly require the file from `hanami-controller`. That module has the proper constant name `CSRFProtection`, instead of the temporary hack (`CsrfProtection`), that it was shipped with this app template.

---

Ref https://trello.com/c/KANJluUV
Ref https://trello.com/c/iGypTkjP