### PR TITLE
Remove `require "json"` from app action

### DIFF
--- a/lib/app_prototype/action.rb
+++ b/lib/app_prototype/action.rb
@@ -1,7 +1,6 @@
 # auto_register: false
 # frozen_string_literal: true
 
-require "json" # required for Hanami::Action::Flash to work
 require "hanami/action"
 
 module AppPrototype


### PR DESCRIPTION
JSON is no longer needed, because we rewrote Action's Flash.

---

Ref https://github.com/hanami/controller/pull/326
Ref https://trello.com/c/KANJluUV