### PR TITLE
Folder fixed for serving static files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ db/*.sqlite
 /node_modules
 /public/assets
 /.assets/tmp/*
+/.assets/node_modules

--- a/config.ru
+++ b/config.ru
@@ -3,7 +3,7 @@
 require "rack/static"
 use Rack::Static,
   urls: ["/assets"],
-  root: "public",
+  root: ".assets/tmp",
   header_rules: [
     ["/assets", {"Cache-Control" => "public, max-age=31536000"}]
   ]


### PR DESCRIPTION
The default root directory is not the one where webpack bundles the assets as mentioned in issue #39 

This PR fixes that.