### PR TITLE
Add shebang to bin/install script

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require "find"
 require "tempfile"
 require "fileutils"


### PR DESCRIPTION
As the README says to run install script by invoking `./bin/install`, a shebang is necessary in that file to make it work.

Fixes #40 