### PR TITLE
Fix default settings

### DIFF
--- a/config/settings.rb
+++ b/config/settings.rb
@@ -6,7 +6,7 @@ require "hanami/application/settings"
 module AppPrototype
   class Settings < Hanami::Application::Settings
     # Framework
-    setting :log_to_stdout, constructor: Types::Params::Bool.optional.default(false)
+    setting :log_to_stdout, false, constructor: Types::Params::Bool.optional
 
     # Database
     setting :database_url, constructor: Types::String
@@ -15,7 +15,7 @@ module AppPrototype
     setting :session_secret, constructor: Types::String
 
     # Assets
-    setting :precompiled_assets, constructor: Types::Params::Bool.optional.default(false)
-    setting :assets_server_url, constructor: Types::String.optional.default("http://localhost:8080")
+    setting :precompiled_assets, false, constructor: Types::Params::Bool.optional
+    setting :assets_server_url, "http://localhost:8080", constructor: Types::String.optional
   end
 end


### PR DESCRIPTION
Defaults stopped working in commit 82d98e5 and since then the settings with defaults were evaluated as `nil`, which is not a big deal for `false` values, but makes a difference for string value. This is visible when inspecting `container[:settings]`:

```
Before aforementioned commit:

#<#<Class:0x00005631dd426a70>:0x00005631dd4264d0 @settings={:log_to_stdout=>false, :database_url=>"sqlite://./db/test_app.sqlite", :session_secret=>"change-me", :precompiled_assets=>false, :assets_server_url=>"http://localhost:8080"}>

After the commit:

#<TestApp::Settings:0x0000557d6aa5cd40 @config=#<Dry::Configurable::Config values={:log_to_stdout=>nil, :database_url=>"sqlite://./db/test_app.sqlite", :session_secret=>"change-me", :precompiled_assets=>false, :assets_server_url=>nil}>>

With changes from this PR:

#<TestApp::Settings:0x0000560981700630 @config=#<Dry::Configurable::Config values={:log_to_stdout=>false, :database_url=>"sqlite://./db/test_app.sqlite", :session_secret=>"change-me", :precompiled_assets=>false, :assets_server_url=>"http://localhost:8080"}>>
```

This has most impact for assets serving in dev - the don't work because they are served from `localhost:3000`, not `localhost:8080`. With the default settings fixed, the are server from dev server (but still don't work because of CSP; this is another story though).