### PR TITLE
Fix Content-Security-Policy for assets

### DIFF
--- a/.assets/webpack.config.js
+++ b/.assets/webpack.config.js
@@ -153,5 +153,6 @@ module.exports = function config(mode) {
         fileName: "manifest.json",
       }),
     ],
+    devtool: 'source-map'
   };
 };

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,6 @@ module AppPrototype
       "img-src 'self' https: data:; " \
       "media-src 'self'; " \
       "object-src 'none'; " \
-      "plugin-types application/pdf; " \
       "script-src 'self' #{settings.assets_server_url}; " \
       "style-src 'self' 'unsafe-inline' https: #{settings.assets_server_url}"
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,6 @@ module AppPrototype
       stream: settings.log_to_stdout ? $stdout : "log/#{Hanami.env}.log"
     }
 
-    assets_server = settings.assets_server_url
     config.actions.default_headers['Content-Security-Policy'] = \
       "base-uri 'self'; " \
       "child-src 'self'; " \
@@ -35,7 +34,7 @@ module AppPrototype
       "media-src 'self'; " \
       "object-src 'none'; " \
       "plugin-types application/pdf; " \
-      "script-src 'self' #{assets_server}; " \
-      "style-src 'self' 'unsafe-inline' https: #{assets_server}"
+      "script-src 'self' #{settings.assets_server_url}; " \
+      "style-src 'self' 'unsafe-inline' https: #{settings.assets_server_url}"
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,22 @@ module AppPrototype
       level: :debug,
       stream: settings.log_to_stdout ? $stdout : "log/#{Hanami.env}.log"
     }
+
+    assets_server = settings.assets_server_url
+    config.actions.default_headers['Content-Security-Policy'] = \
+      "base-uri 'self'; " \
+      "child-src 'self'; " \
+      "connect-src 'self'; " \
+      "default-src 'none'; " \
+      "font-src 'self'; " \
+      "form-action 'self'; " \
+      "frame-ancestors 'self'; " \
+      "frame-src 'self'; " \
+      "img-src 'self' https: data:; " \
+      "media-src 'self'; " \
+      "object-src 'none'; " \
+      "plugin-types application/pdf; " \
+      "script-src 'self' #{assets_server}; " \
+      "style-src 'self' 'unsafe-inline' https: #{assets_server}"
   end
 end


### PR DESCRIPTION
Together with #43 it should make assets work out of the box for the template. This was manually tested for CSS and JS assets.

* CSP needs to allow scripts and styles from assets server url
* Webpack uses `eval` a lot by default, which also breaks CSP. The easiest way to work aroud that is to turn on source maps. Perhaps we  could use inline-source-map in dev and source-map in production, but   I'm not 100% sure it'd be correct.