### PR TITLE
Fix default port exposed in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     command: script/puma
     env_file: ".env"
     ports:
-      - 3000:3000
+      - 2300:2300
     depends_on:
       - assets
     links:


### PR DESCRIPTION
Puma is using port 2300 by default:

https://github.com/hanami/hanami-2-application-template/blob/9a23a1b331dc0ee7629099d0d6320a3f341e4885/config/puma.rb#L23