### PR TITLE
Update to database_cleaner-sequel 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group :test do
   gem "capybara", "~> 3.0"
   gem "capybara-screenshot", "~> 1.0"
   gem "cuprite", "~> 0.8"
-  gem "database_cleaner", "~> 1.7"
+  gem "database_cleaner-sequel", "~> 2.0"
   gem "puffing-billy", "~> 2.2"
   gem "rspec", "~> 3.9"
   gem "simplecov", "~> 0.17"

--- a/spec/support/db/database_cleaner.rb
+++ b/spec/support/db/database_cleaner.rb
@@ -1,21 +1,21 @@
-require "database_cleaner"
+require "database_cleaner/sequel"
 require_relative "helpers"
 
-DatabaseCleaner[:sequel, connection: Test::DB::Helpers.db].strategy = :transaction
+DatabaseCleaner[:sequel].strategy = :transaction
 
 RSpec.configure do |config|
   config.before :suite do
-    DatabaseCleaner.clean_with :truncation
+    DatabaseCleaner[:sequel].clean_with :truncation
   end
 
   config.prepend_before :each, :db do |example|
     strategy = example.metadata[:js] ? :truncation : :transaction
-    DatabaseCleaner.strategy = strategy
+    DatabaseCleaner[:sequel].strategy = strategy
 
-    DatabaseCleaner.start
+    DatabaseCleaner[:sequel].start
   end
 
   config.append_after :each, :db do
-    DatabaseCleaner.clean
+    DatabaseCleaner[:sequel].clean
   end
 end


### PR DESCRIPTION
database_cleaner 2.0 ships with a separated adapter for sequel.

We update the database_cleaner configuration to adopt the new setup.

On top of that, previous to this commit, the configuration with
database_cleaner `~> 1.7` wasn't working with the SQLite adapter OOTB. That was
because database_cleaner expected `sqlite3` as the adapter name to
consider a connection as local and therefore allow it:

https://github.com/DatabaseCleaner/database_cleaner/pull/529/commits/7519d4381073dbcdda732a09d7c92a70fe312f8c

On the other hand, Sequel uses `sqlite` (without the `3`) as the adapter name:

https://github.com/jeremyevans/sequel/blob/2392145025c60d3c127bc1b921130598409f249c/lib/sequel/database/connecting.rb#L11

To work around that, one needed to disable [database_cleaner
safeguards](https://github.com/DatabaseCleaner/database_cleaner#safeguards).
However, with the new adapter there's no need to do that.