### PR TITLE
Add a guard for capitalized letters in the app name

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -9,7 +9,7 @@ require 'open3'
 class Installer
   class << self
     def call(app_name)
-      rename_app app_name
+      return unless rename_app(app_name)
       install_readme
       bundle_install
       generate_cli_binstub
@@ -21,6 +21,11 @@ class Installer
     private
 
     def rename_app(app_name)
+      if /[A-Z]/.match(app_name)
+        puts "Capital letters can lead to unexpected results."
+        puts "Underscore your app name instead (i.e. #{app_name.downcase})."
+        return
+      end
       rename_file_contents(app_name)
       rename_file_names(app_name)
     end
@@ -48,7 +53,7 @@ class Installer
         new_name = orig_name.sub("app_prototype", app_name)
         FileUtils.mv(orig_name, new_name, force: true, verbose: true) unless orig_name == new_name
       end
-      dirs.reverse.each do |orig_name| 
+      dirs.reverse.each do |orig_name|
         new_name = orig_name.sub("app_prototype", app_name)
         FileUtils.mv(orig_name, new_name, force: true, verbose: true) unless orig_name == new_name
       end
@@ -167,7 +172,7 @@ class Installer
         unless exit_status.success?
           raise "#{command} failed with status #{exit_status}\n"
         end
-      end 
+      end
     end
 
   end

--- a/bin/install
+++ b/bin/install
@@ -24,7 +24,7 @@ class Installer
       if /[A-Z]/.match(app_name)
         puts "Capital letters can lead to unexpected results."
         puts "Underscore your app name instead (i.e. #{app_name.downcase})."
-        return
+        return false
       end
       rename_file_contents(app_name)
       rename_file_names(app_name)


### PR DESCRIPTION
When user passes a string containing capitalized letters (i.e: "Sandbox")
as an app name during the installation process, the `lib/Sandbox` folder
will be generated and none of the app-specific settings will be taken into
the account.