### PR TITLE
Changed stylesheet and script sources to "main/public.*"

### DIFF
--- a/slices/main/web/templates/layouts/application.html.slim
+++ b/slices/main/web/templates/layouts/application.html.slim
@@ -8,8 +8,8 @@ html
         ' /
       ' AppPrototype
     meta name="title" content="AppPrototype"
-    link rel="stylesheet" type="text/css" href=assets["main__public.css"]
-    script src=assets["main__public.js"] defer=true
+    link rel="stylesheet" type="text/css" href=assets["main/public.css"]
+    script src=assets["main/public.js"] defer=true
 
   body
     == yield


### PR DESCRIPTION
While trying the template, I found that the sources for both the `css` and `js` compiled files were wrong and throwing an error on the JS console in the browser. I changed them accordingly

Fixes #55 