### PR TITLE
Add prettier to dev dependencies and use default config

### DIFF
--- a/.assets/babel.config.js
+++ b/.assets/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = (api) => {
-  api.cache(true)
+  api.cache(true);
   return {
     presets: [
       [
@@ -26,5 +26,5 @@ module.exports = (api) => {
       "@babel/preset-react",
     ],
     sourceType: "unambiguous",
-  }
-}
+  };
+};

--- a/.assets/scripts/build.ts
+++ b/.assets/scripts/build.ts
@@ -1,8 +1,8 @@
-import { config } from "../webpack.config"
-import chalk from "chalk"
-import path from "path"
-import rimraf from "rimraf"
-import webpack from "webpack"
+import { config } from "../webpack.config";
+import chalk from "chalk";
+import path from "path";
+import rimraf from "rimraf";
+import webpack from "webpack";
 
 /*
 Build webpack bundle
@@ -15,33 +15,33 @@ Build webpack bundle
 That's all. You won't even find a dev server in here!
 **********************************************************/
 
-const mode = process.argv[2]
-const bundleConfig = config(mode) as webpack.Configuration
+const mode = process.argv[2];
+const bundleConfig = config(mode) as webpack.Configuration;
 
 if (bundleConfig.output?.path != null) {
   rimraf(
     path.resolve(bundleConfig.output.path, "./*"),
     (error?: Error | null): void => {
       if (error) {
-        console.error(chalk.red(error))
-        process.exit()
+        console.error(chalk.red(error));
+        process.exit();
       }
 
       const watching = webpack([bundleConfig]).watch(
         {},
         (_err, compilation): void => {
-          if (compilation === undefined) return
+          if (compilation === undefined) return;
 
           compilation.stats.forEach((stats) => {
-            console.log(stats.toString({ colors: true }))
-          })
+            console.log(stats.toString({ colors: true }));
+          });
 
           if (mode === "production") {
-            watching.close(() => {})
-            if (compilation.hasErrors()) process.exit(1)
+            watching.close(() => {});
+            if (compilation.hasErrors()) process.exit(1);
           }
         }
-      )
+      );
     }
-  )
+  );
 }

--- a/.assets/webpack.config.ts
+++ b/.assets/webpack.config.ts
@@ -1,12 +1,12 @@
-import { WebpackManifestPlugin } from "webpack-manifest-plugin"
-import cssnano from "cssnano"
-import glob from "glob"
-import MiniCssExtractPlugin from "mini-css-extract-plugin"
-import path from "path"
-import postcssImport from "postcss-import"
-import postcssPresetEnv from "postcss-preset-env"
-import postcssUrl from "postcss-url"
-const postcssCssVariables = require("postcss-css-variables")
+import { WebpackManifestPlugin } from "webpack-manifest-plugin";
+import cssnano from "cssnano";
+import glob from "glob";
+import MiniCssExtractPlugin from "mini-css-extract-plugin";
+import path from "path";
+import postcssImport from "postcss-import";
+import postcssPresetEnv from "postcss-preset-env";
+import postcssUrl from "postcss-url";
+const postcssCssVariables = require("postcss-css-variables");
 
 const cssLoaders = (
   mode: string,
@@ -43,7 +43,7 @@ const cssLoaders = (
       },
     },
   },
-]
+];
 
 export const config = (mode: string): Record<string, unknown> => ({
   devtool: mode === "production" ? undefined : "cheap-module-source-map",
@@ -57,17 +57,17 @@ export const config = (mode: string): Record<string, unknown> => ({
       glob.sync(`${dir}/**/entry.{js,jsx,ts,tsx}`).map((entry) => {
         const entryName = entry.includes("/assets/")
           ? entry.split(`${dir}/assets/`).slice(-1)[0].split("/entry.")[0]
-          : path.basename(path.dirname(entry))
-        return [`${path.basename(dir)}/${entryName}`, entry]
+          : path.basename(path.dirname(entry));
+        return [`${path.basename(dir)}/${entryName}`, entry];
       })
     )
     // Flatten
     .reduce((a, b) => a.concat(b), [])
     // Turn into `entry` object
     .reduce((output: Record<string, unknown>, entry) => {
-      const [name, location] = entry
-      output[name] = [location]
-      return output
+      const [name, location] = entry;
+      output[name] = [location];
+      return output;
     }, {}),
   mode,
   module: {
@@ -142,4 +142,4 @@ export const config = (mode: string): Record<string, unknown> => ({
     }),
     new WebpackManifestPlugin({ fileName: "manifest.json" }),
   ],
-})
+});

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,3 @@
 {
-  "semi": false,
-  "trailingComma": "es5",
   "quoteProps": "consistent"
 }

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "test": "jest",
     "build-production": "yarn run build",
     "heroku-postbuild": "yarn run build"
+  },
+  "dependencies": {
+    "prettier": "^2.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "license": "UNLICENSED",
   "repository": {},
   "devDependencies": {
-    "application-assets": "file:.assets"
+    "application-assets": "file:.assets",
+    "prettier": "^2.4.1"
   },
   "engines": {
     "node": "16",
@@ -20,8 +21,5 @@
     "test": "jest",
     "build-production": "yarn run build",
     "heroku-postbuild": "yarn run build"
-  },
-  "dependencies": {
-    "prettier": "^2.4.1"
   }
 }

--- a/slices/main/assets/public/entry.ts
+++ b/slices/main/assets/public/entry.ts
@@ -1,9 +1,9 @@
 // Automatically polyfill based on browserlists configuration in babel.config
-import "core-js/stable"
+import "core-js/stable";
 
 // Import base JS/CSS definitions
-import "./index.ts"
-import "./index.css"
+import "./index.ts";
+import "./index.css";
 
 // This will inspect all subdirectories from the context (this file) and
 // require files matching the regex.
@@ -12,4 +12,4 @@ require.context(
   ".",
   true,
   /^\.\/.*\.(jpe?g|png|gif|svg|woff2?|ttf|otf|eot|ico|mp4|m4v|pdf)$/
-)
+);


### PR DESCRIPTION
Prettier is required for the `format` task, so this PR makes sure we include it in the deps. Also, I removed the overrides for semicolon and trailing commas in favor of the default prettier config.