### PR TITLE
Use default browserslist config and auto setting more modules in babel

### DIFF
--- a/.assets/babel.config.js
+++ b/.assets/babel.config.js
@@ -5,22 +5,12 @@ module.exports = (api) => {
       [
         "@babel/preset-env",
         {
-          modules: false,
+          modules: "auto",
           useBuiltIns: "entry",
           corejs: {
             version: 3,
           },
-          targets: {
-            browsers: [
-              "> 1% in AU",
-              "last 2 versions",
-              "Firefox ESR",
-              "not ie < 11",
-              "iOS >= 8.4",
-              "Safari >= 8",
-              "Android >= 4.4",
-            ],
-          },
+          targets: "defaults"
         },
       ],
       "@babel/preset-react",


### PR DESCRIPTION
### Browserslist

I think using the defaults that browserslist recommends is better than specifying exact versions, since they do a lot of the heavy lifting of deciding what makes sense for most users.

### Babel Config

Using the `auto` setting for modules when using babel is recommended. From [the @babel/preset-env docs](https://babeljs.io/docs/en/babel-preset-env#modules):

> Setting this to false will preserve ES modules. Use this only if you intend to ship native ES Modules to browsers. If you are using a bundler with Babel, the default modules: "auto" is always preferred.

