### PR TITLE
Content Security Policy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,9 @@ source "https://rubygems.org/"
 gem "rake", "~> 13.0"
 
 # Application framework
-gem "hanami", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/hanami.git", branch: "feature/content-security-policy"
+gem "hanami", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/hanami.git", branch: "main"
 gem "hanami-cli", "~> 2.0.0.alpha"
-gem "hanami-controller", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/controller.git", branch: "feature/content-security-policy"
+gem "hanami-controller", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/controller.git", branch: "main"
 gem "hanami-router", "~> 2.0.0.alpha"
 gem "hanami-utils", "~> 2.0.0.alpha"
 gem "hanami-view", "~> 2.0.0.alpha"

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,9 @@ source "https://rubygems.org/"
 gem "rake", "~> 13.0"
 
 # Application framework
-gem "hanami", "~> 2.0.0.alpha"
+gem "hanami", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/hanami.git", branch: "feature/content-security-policy"
 gem "hanami-cli", "~> 2.0.0.alpha"
-gem "hanami-controller", "~> 2.0.0.alpha"
+gem "hanami-controller", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/controller.git", branch: "feature/content-security-policy"
 gem "hanami-router", "~> 2.0.0.alpha"
 gem "hanami-utils", "~> 2.0.0.alpha"
 gem "hanami-view", "~> 2.0.0.alpha"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/hanami/controller.git
-  revision: a1540fa283140d1c84cacd9dfae18c17028b4181
-  branch: feature/content-security-policy
+  revision: 3055cadb3791de3cf9227f46dfffe7ca691b59ae
+  branch: main
   specs:
     hanami-controller (2.0.0.alpha3)
       dry-configurable (~> 0.13, >= 0.13.0)
@@ -10,8 +10,8 @@ GIT
 
 GIT
   remote: https://github.com/hanami/hanami.git
-  revision: b7110c3e486a2ace4690e8f0a03705e637070ba2
-  branch: feature/content-security-policy
+  revision: 3a56d3bf25223bda47bafdc9e650085bbe85a92a
+  branch: main
   specs:
     hanami (2.0.0.alpha3)
       bundler (>= 1.16, < 3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,29 @@
+GIT
+  remote: https://github.com/hanami/controller.git
+  revision: a1540fa283140d1c84cacd9dfae18c17028b4181
+  branch: feature/content-security-policy
+  specs:
+    hanami-controller (2.0.0.alpha3)
+      dry-configurable (~> 0.13, >= 0.13.0)
+      hanami-utils (~> 2.0.alpha)
+      rack (~> 2.0)
+
+GIT
+  remote: https://github.com/hanami/hanami.git
+  revision: b7110c3e486a2ace4690e8f0a03705e637070ba2
+  branch: feature/content-security-policy
+  specs:
+    hanami (2.0.0.alpha3)
+      bundler (>= 1.16, < 3)
+      dry-configurable (~> 0.12, >= 0.12.1)
+      dry-core (~> 0.4)
+      dry-inflector (~> 0.2, >= 0.2.1)
+      dry-monitor
+      dry-system (~> 0.19, >= 0.21.0)
+      hanami-cli (~> 2.0.alpha)
+      hanami-utils (~> 2.0.alpha)
+      zeitwerk (~> 2.4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -132,26 +158,12 @@ GEM
       ffi
       guard (~> 2.3)
       spoon
-    hanami (2.0.0.alpha3)
-      bundler (>= 1.16, < 3)
-      dry-configurable (~> 0.12, >= 0.12.1)
-      dry-core (~> 0.4)
-      dry-inflector (~> 0.2, >= 0.2.1)
-      dry-monitor
-      dry-system (~> 0.19, >= 0.21.0)
-      hanami-cli (~> 2.0.alpha)
-      hanami-utils (~> 2.0.alpha)
-      zeitwerk (~> 2.4)
     hanami-cli (2.0.0.alpha3)
       bundler (~> 2.1)
       dry-cli (~> 0.6)
       dry-files (~> 0.1)
       dry-inflector (~> 0.2)
       rake (~> 13.0)
-    hanami-controller (2.0.0.alpha3)
-      dry-configurable (~> 0.13, >= 0.13.0)
-      hanami-utils (~> 2.0.alpha)
-      rack (~> 2.0)
     hanami-router (2.0.0.alpha5)
       mustermann (~> 1.0)
       mustermann-contrib (~> 1.0)
@@ -338,9 +350,9 @@ DEPENDENCIES
   dry-validation (~> 1.4)
   erbse (~> 0.1)
   guard-rack (~> 2.2)
-  hanami (~> 2.0.0.alpha)
+  hanami (~> 2.0.alpha)!
   hanami-cli (~> 2.0.0.alpha)
-  hanami-controller (~> 2.0.0.alpha)
+  hanami-controller (~> 2.0.alpha)!
   hanami-router (~> 2.0.0.alpha)
   hanami-utils (~> 2.0.0.alpha)
   hanami-view (~> 2.0.0.alpha)

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,20 +18,5 @@ module AppPrototype
 
     config.logger.options[:level] = :debug
     config.logger.options[:stream] = settings.log_to_stdout ? $stdout : "log/#{Hanami.env}.log"
-
-    config.actions.default_headers['Content-Security-Policy'] = \
-      "base-uri 'self'; " \
-      "child-src 'self'; " \
-      "connect-src 'self'; " \
-      "default-src 'none'; " \
-      "font-src 'self'; " \
-      "form-action 'self'; " \
-      "frame-ancestors 'self'; " \
-      "frame-src 'self'; " \
-      "img-src 'self' https: data:; " \
-      "media-src 'self'; " \
-      "object-src 'none'; " \
-      "script-src 'self' #{settings.assets_server_url}; " \
-      "style-src 'self' 'unsafe-inline' https: #{settings.assets_server_url}"
   end
 end

--- a/config/boot/assets.rb
+++ b/config/boot/assets.rb
@@ -9,7 +9,7 @@ Hanami.application.register_bootable :assets do |container|
     assets = Framework::Web::Assets.new(
       root: Hanami.application.root,
       precompiled: Hanami.env == :production || container[:settings].precompiled_assets,
-      server_url: container[:settings].assets_server_url
+      server_url: Hanami.application.configuration.assets.server_url
     )
 
     register "assets", assets

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -16,6 +16,5 @@ module AppPrototype
 
     # Assets
     setting :precompiled_assets, constructor: Types::Params::Bool, default: false
-    setting :assets_server_url, constructor: Types::String, default: "http://localhost:8080"
   end
 end


### PR DESCRIPTION
Let the defaults of Content Security Policy to be handled by the [framework](https://github.com/hanami/controller/pull/353).

Hanami [introduces](https://github.com/hanami/hanami/pull/1131) a new configuration to handle assets' server URL: `config.assets.server_url`.