### PR TITLE
Fix equality conditional syntax in `script/bootstrap`

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -7,7 +7,7 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-if [ "$1" == "docker" ]; then
+if [ "$1" = "docker" ]; then
   docker-compose run --rm app "bundle"
   docker-compose run --rm --entrypoint "/bin/sh -lc" assets "npm install"
 else


### PR DESCRIPTION
Just a tiny fix for an invalid conditional in this script.

It currently says the following (and as a result running `script/bootstrap docker` will never work):

```
$ ./script/bootstrap foo
./script/bootstrap: 10: [: foo: unexpected operator
```