### PR TITLE
Fix Hanami.application.start persistence for specs

### DIFF
--- a/spec/support/db.rb
+++ b/spec/support/db.rb
@@ -6,7 +6,7 @@ require_relative "db/factory"
 
 RSpec.configure do |config|
   config.before :suite do
-    Hanami.application.start_bootable :persistence
+    Hanami.application.start :persistence
   end
 
   config.include Test::DB::Helpers, :db


### PR DESCRIPTION
`Hanami.application.start_bootable` was renamed to `Hanami.application.start` in Hanami v2.0.0.alpha6

See: https://github.com/hanami/hanami/commit/8bb320cac55d93bb1bb79d0831b4c27f4436047d\#diff-821c48c88c392a3a4fb873393e0c3c8401ca598885b47e1cfe8c0d4c57932293L154-L156