### PR TITLE
[FIX] add file required by repository

### DIFF
--- a/lib/app_prototype/entities.rb
+++ b/lib/app_prototype/entities.rb
@@ -1,0 +1,4 @@
+module AppPrototype
+  module Entities
+  end
+end


### PR DESCRIPTION
This comes up after adding the first repository. The AppPrototype::Repository requires "entities".