### PR TITLE
Fix install script for app with kebab-case name

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -48,13 +48,14 @@ class Installer
     end
 
     def rename_file_names(app_name)
+      snake_name = app_name.tr("-", "_")
       files, dirs = find_files_for_rename.partition{ |f| File.file? f }
       files.each do |orig_name|
-        new_name = orig_name.sub("app_prototype", app_name)
+        new_name = orig_name.sub("app_prototype", snake_name)
         FileUtils.mv(orig_name, new_name, force: true, verbose: true) unless orig_name == new_name
       end
       dirs.reverse.each do |orig_name|
-        new_name = orig_name.sub("app_prototype", app_name)
+        new_name = orig_name.sub("app_prototype", snake_name)
         FileUtils.mv(orig_name, new_name, force: true, verbose: true) unless orig_name == new_name
       end
     end


### PR DESCRIPTION
When the `bin/install` script is invoked with a name in kebab case (e.g. `test-app`), the result is incorrect. After starting the server, we end up with a cryptic error message:

```
bundler: failed to load command: rackup (/home/katafrakt/.asdf/installs/ruby/3.0.2/bin/rackup)
/home/katafrakt/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/hanami-2.0.0.alpha8/lib/hanami/application/settings.rb:84:in `method_missing': undefined method `session_secret' for #<Hanami::Application::Settings:0x00005567d2bae480 @config=#<Dry::Configurable::Config values={}>> (NoMethodError)
```

This is due to the fact that there is a `LoadError` when trying to require settings - it attempts to `require 'test-app/types`, but the path is `lib/test_app/types.rb`. Because of that, if silently falls back to default settings, which do not have `session_secret`. The error itself will be better after merging https://github.com/hanami/hanami/pull/1166, but the issue will still persist.