### PR TITLE
Fix/legacy rack app usage

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 require "hanami/boot"
-run Hanami.rack_app
+run Hanami.app

--- a/spec/support/web.rb
+++ b/spec/support/web.rb
@@ -2,5 +2,5 @@
 
 require "capybara/rspec"
 
-Capybara.app = Hanami.rack_app
+Capybara.app = Hanami.app
 Capybara.server = :puma, {Silent: true}


### PR DESCRIPTION
### Overview

After recent changes, Hanami 2 app template stopped working out-of-the-box due to the `undefined method "rack_app" called on Hanami Module`.

After recent changes, `Hanami.rack_app` had been renamed to `Hanami.app`.

This PR fixes that, tests pass after the change.